### PR TITLE
fix: duplicate definitions for CP_THIN_HORIZONTAL_THIN_DOWN

### DIFF
--- a/include/cp/cp437.h
+++ b/include/cp/cp437.h
@@ -522,7 +522,7 @@ extern const wchar_t* const CP_WCHAR_LOOKUP_TABLE;
 // "╤"
 #define CP_THICK_HORIZONTAL_THIN_DOWN 209
 // "╥"
-#define CP_THIN_HORIZONTAL_THIN_DOWN 210
+#define CP_THIN_HORIZONTAL_THICK_DOWN 210
 // "╙"
 #define CP_THIN_RIGHT_THICK_UP 211
 // "╘"


### PR DESCRIPTION
210 was mistakenly defined as "CP_THIN_HORIZONTAL_THIN_DOWN" but it should be "CP_THIN_HORIZONTAL_THICK_DOWN"

Came across this as this failed to compile with OpenWatcom C v2

Looked it up on Wikipedia: https://en.wikipedia.org/wiki/Code_page_437