### PR TITLE
cp437.h: Fix comment typo

### DIFF
--- a/include/cp/cp437.h
+++ b/include/cp/cp437.h
@@ -58,7 +58,7 @@
           2. Link it with the CMake target of your project:
                 target_link_libraries(YOUR_TARGET_NAME PRIVATE cp::cp)
 
-    Include this file in one .c or .cpp within your project after defining the implemention macro
+    Include this file in one .c or .cpp within your project after defining the implementation macro
     like so:
 
         #define CP437_IMPLEMENTATION


### PR DESCRIPTION
Codespell picks up a typo:

cp437.h:61: implemention ==> implementation

Fix the typo.